### PR TITLE
Merge variable attributes when adding templates

### DIFF
--- a/ncwriter/template.py
+++ b/ncwriter/template.py
@@ -96,8 +96,12 @@ class NetCDFGroupDict(object):
     def __add__(self, other):
         self_copy = deepcopy(self)
         self_copy.dimensions.update(other.dimensions)
-        self_copy.variables.update(other.variables)
         self_copy.global_attributes.update(other.global_attributes)
+        for k, v in other.variables.items():
+            if k in self_copy.variables:
+                self_copy.variables[k].update(v)
+            else:
+                self_copy.variables[k] = v
         return self_copy
 
     @property

--- a/test_ncwriter/test_template.py
+++ b/test_ncwriter/test_template.py
@@ -115,6 +115,30 @@ class TestDatasetTemplate(BaseTestCase):
         self.assertEqual(tdict['_variables'], template.variables)
         self.assertEqual(metadata_attributes(tdict), template.global_attributes)
 
+    def test_add_method(self):
+        template1 = DatasetTemplate(dimensions={'ONE': 1},
+                                    variables={'X': {'_dimensions': ['ONE'], '_datatype': 'float32'},
+                                               'Y': {'_dimensions': ['ONE'], '_datatype': 'float32'}
+                                               },
+                                    global_attributes={'title': 'First template', 'comment': 'one'}
+                                    )
+        template2 = DatasetTemplate(dimensions={'TWO': 2},
+                                    variables={'Y': {'_dimensions': ['TWO'], 'comment': 'updated'},
+                                               'Z': {'name': 'new'}
+                                               },
+                                    global_attributes={'title': 'Second template', 'version': 2}
+                                    )
+        template = template1 + template2
+
+        self.assertEqual({'ONE': 1, 'TWO': 2}, template.dimensions)
+        self.assertEqual({'title': 'Second template', 'comment': 'one', 'version': 2}, template.global_attributes)
+
+        self.assertSetEqual({'X', 'Y', 'Z'}, set(template.variables.keys()))
+        self.assertEqual({'_dimensions': ['ONE'], '_datatype': 'float32'}, template.variables['X'])
+        self.assertEqual({'_dimensions': ['TWO'], '_datatype': 'float32', 'comment': 'updated'},
+                         template.variables['Y'])
+        self.assertEqual({'name': 'new'}, template.variables['Z'])
+
     # TODO: def test_json_validation(self):
 
     # TODO: create template from other formats (later...)


### PR DESCRIPTION
The `DatasetTemplate` class has an `__add__` method, which allows two templates to be added together. This now behaves as expected, merging the corresponding dimensions, global_attributes and variables dictionaries together.

This PR fixes the merging of the variable dicts, which requires a bit more care when both templates being added include the same variable name.